### PR TITLE
added --strict-utf8 option to convert SQL_ASCII data to UTF8 in Postgres

### DIFF
--- a/bin/fix_latin
+++ b/bin/fix_latin
@@ -24,7 +24,7 @@ use Encoding::FixLatin qw(fix_latin);
 
 my %opt;
 
-if(!GetOptions(\%opt, 'help|?', 'version|v', 'use_xs|use-xs=s')) {
+if(!GetOptions(\%opt, 'help|?', 'version|v', 'use_xs|use-xs=s', 'strict_utf8|strict-utf8')) {
     pod2usage(-exitval => 1,  -verbose => 0);
 }
 
@@ -41,9 +41,10 @@ if($opt{version}) {
 }
 
 my @use_xs = ( use_xs => $opt{use_xs} || 'auto' );
+my @strict_utf8 = (strict_utf8 => $opt{strict_utf8} || 0);
 
 while(<>) {
-    $_ = fix_latin($_, bytes_only => 1, @use_xs) if /[^\x00-\x7f]/;
+    $_ = fix_latin($_, bytes_only => 1, @use_xs, @strict_utf8) if /[^\x00-\x7f]/;
     print;
 }
 
@@ -89,6 +90,14 @@ byte characters will be converted as follows:
 Override default ('auto') behaviour of trying to use XS module and falling back
 to pure-Perl version if not available.  Set to 'never' to always use the Perl
 version or 'always' to always use XS and die if not available.
+
+=item B<--strict-utf8>
+
+Do not allow "invalid" UTF-8 to pass on through; invalid UTF-8 characters will
+be substituted by '?'. Enabling this option will disable the use of XS module.
+The criteria to evaluate if UTF-8 is valid have been taken from Postgresql.
+Indeed, this option is mainly intended to be used to convert Postgresql DB dump
+data from SQL_ASCII encoding to UTF-8.
 
 =item B<--version> (alias -v)
 

--- a/lib/Encoding/FixLatin.pm
+++ b/lib/Encoding/FixLatin.pm
@@ -278,6 +278,11 @@ sub _pg_utf8_islegal {
       if ($a > 0xF4) {
           return 0;
       }
+      if ($a == 0x0A || $a == 0x0D) {
+          # C08A and C08D are decoded as 0A and 0D by sub _decode_utf8, 
+          # but it is not a valid conversion
+          return 0; 
+      }
   }
   return 1;
 }

--- a/lib/Encoding/LICENSE.postgres
+++ b/lib/Encoding/LICENSE.postgres
@@ -1,0 +1,27 @@
+--------------------------------------------------------------------------------
+            License for sub _pg_utf8_is_legal in FixLatin.pm
+--------------------------------------------------------------------------------
+
+PostgreSQL Database Management System
+(formerly known as Postgres, then as Postgres95)
+
+Portions Copyright (c) 1996-2019, PostgreSQL Global Development Group
+
+Portions Copyright (c) 1994, The Regents of the University of California
+
+Permission to use, copy, modify, and distribute this software and its
+documentation for any purpose, without fee, and without a written agreement
+is hereby granted, provided that the above copyright notice and this
+paragraph and the following two paragraphs appear in all copies.
+
+IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY FOR
+DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS
+DOCUMENTATION, EVEN IF THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ON AN "AS IS" BASIS, AND THE UNIVERSITY OF CALIFORNIA HAS NO OBLIGATIONS TO
+PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.


### PR DESCRIPTION
I was in need to convert a Postgres db with SQL_ASCII encoding in UTF8, and I found [this blog post](https://www.endpoint.com/blog/2017/07/21/postgres-migrating-sqlascii-to-utf-8)
that suggested a modification to fix_latin in order to handle "invalid" UTF-8 characters that may cause postgresql errors during data (re)importing.
I implemented such modification here.